### PR TITLE
Referral 

### DIFF
--- a/runtime/src/extensions/check_account.rs
+++ b/runtime/src/extensions/check_account.rs
@@ -69,7 +69,7 @@ impl SignedExtension for CheckAccount {
 
 	fn validate(
 		&self,
-		who: &Self::AccountId,
+		_who: &Self::AccountId,
 		call: &Self::Call,
 		_info: &DispatchInfoOf<Self::Call>,
 		_len: usize,
@@ -83,7 +83,6 @@ impl SignedExtension for CheckAccount {
 					// User already is registered, can execute transaction
 					Ok(ValidTransaction::default())
 				} else {
-					pallet_appreciation::Referrals::<Runtime>::insert(who, to, ());
 					// User is not registered need to provide tag to wait,
 					// until `new_user` transaction provide this tag
 					let requires = vec![Encode::encode(&(to))];


### PR DESCRIPTION
# How it works:
When new user registered by `new_user` transaction we add record to the storage. In the end of the block storage with this records will be cleared, using `on_finalize` hook in `pallet_appreciation`. When appreciation transaction happens it check the storage and delete those value if exist, if storage contains record about appreciated account that means that appreciation is referral.