### PR TITLE
RPC methods naming

### DIFF
--- a/client/rpc-api/src/chain/mod.rs
+++ b/client/rpc-api/src/chain/mod.rs
@@ -8,11 +8,11 @@ use sp_runtime::traits::Block as BlockT;
 #[rpc(client, server)]
 pub trait BlocksProviderApi<Block: BlockT, AccountId> {
 	/// RPC method provides block information by block number
-	#[method(name = "get_block_info", blocking)]
+	#[method(name = "chain_get_block_info", blocking)]
 	fn get_block_info(&self, block_height: u32) -> RpcResult<RpcBlock<AccountId, Block::Hash>>;
 
 	/// RPC method provides blocks information by the range of blocks number
-	#[method(name = "get_blocks", blocking)]
+	#[method(name = "chain_get_blocks", blocking)]
 	fn get_blocks(
 		&self,
 		from_block_height: u32,
@@ -24,10 +24,10 @@ pub trait BlocksProviderApi<Block: BlockT, AccountId> {
 	}
 
 	/// RPC method provides information about current blockchain state
-	#[method(name = "get_blockchain_data")]
+	#[method(name = "chain_get_blockchain_data")]
 	fn get_blockchain_data(&self) -> RpcResult<BlockchainStats>;
 
 	/// RPC method provides information about blockchain genesis config
-	#[method(name = "get_genesis_data")]
+	#[method(name = "chain_get_genesis_data")]
 	fn get_genesis_data(&self) -> RpcResult<GenesisData<AccountId>>;
 }

--- a/client/rpc-api/src/events/mod.rs
+++ b/client/rpc-api/src/events/mod.rs
@@ -7,7 +7,7 @@ use sp_runtime::traits::Block as BlockT;
 #[rpc(client, server)]
 pub trait EventsProviderApi<Block: BlockT, Event> {
 	/// RPC method provides events for specific blocks
-	#[method(name = "get_blockchain_events", blocking)]
+	#[method(name = "events_get_blockchain_events", blocking)]
 	fn get_blockchain_events(
 		&self,
 		from_block_height: u32,

--- a/client/rpc-api/src/transactions/mod.rs
+++ b/client/rpc-api/src/transactions/mod.rs
@@ -11,7 +11,7 @@ use sp_runtime::traits::{Block as BlockT, NumberFor};
 #[rpc(client, server)]
 pub trait TransactionsIndexerApi<Block: BlockT, AccountId, Signature, Event> {
 	/// RPC method provides transaction details by block number and transaction index
-	#[method(name = "get_tx", blocking)]
+	#[method(name = "transactions_get_tx", blocking)]
 	fn get_tx(
 		&self,
 		block_number: NumberFor<Block>,
@@ -20,7 +20,7 @@ pub trait TransactionsIndexerApi<Block: BlockT, AccountId, Signature, Event> {
 
 	/// RPC method provides transaction details and transaction events by block number and
 	/// transaction index
-	#[method(name = "get_tx_with_events", blocking)]
+	#[method(name = "transactions_get_tx_with_events", blocking)]
 	fn get_tx_with_events(
 		&self,
 		block_number: NumberFor<Block>,
@@ -28,14 +28,14 @@ pub trait TransactionsIndexerApi<Block: BlockT, AccountId, Signature, Event> {
 	) -> RpcResult<(SignedTransactionWithStatus<AccountId, Signature>, Vec<Event>)>;
 
 	/// RPC method provides transaction details by transaction hash
-	#[method(name = "get_transaction", blocking)]
+	#[method(name = "transactions_get_transaction", blocking)]
 	fn get_transaction(
 		&self,
 		tx_hash: Block::Hash,
 	) -> RpcResult<GetTransactionResponse<AccountId, Signature, Event>>;
 
 	/// RPC method provides transactions details by transactions hashes
-	#[method(name = "get_transaction_from_hashes", blocking)]
+	#[method(name = "transactions_get_transaction_from_hashes", blocking)]
 	fn get_transactions_from_hashes(
 		&self,
 		tx_hashes: Vec<Block::Hash>,
@@ -57,7 +57,7 @@ pub trait TransactionsIndexerApi<Block: BlockT, AccountId, Signature, Event> {
 	}
 
 	/// RPC method provides transactions, that belong to specific account
-	#[method(name = "get_transactions", blocking)]
+	#[method(name = "transactions_get_transactions", blocking)]
 	fn get_transactions(
 		&self,
 		account_id: AccountId,

--- a/client/rpc-api/src/verifier/mod.rs
+++ b/client/rpc-api/src/verifier/mod.rs
@@ -6,7 +6,7 @@ use sp_rpc::{ByPassToken, VerificationResponse};
 
 #[rpc(client, server)]
 pub trait VerifierApi<AccountId, Username, PhoneNumber> {
-	#[method(name = "verify")]
+	#[method(name = "verifier_verify")]
 	async fn verify(
 		&self,
 		account_id: AccountId,


### PR DESCRIPTION
Polkadot API requires RPC method to be in next format `{module}_{method_name}`