### PR TITLE
RPC methods naming should be in camelCase

### DIFF
--- a/.postman/karmachain-rpc.postman_collection.json
+++ b/.postman/karmachain-rpc.postman_collection.json
@@ -127,7 +127,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"community_get_all_users\",\n    \"params\": {\n        \"community_id\": 0\n    }\n}"
+							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"community_getAllUsers\",\n    \"params\": {\n        \"community_id\": 0\n    }\n}"
 						},
 						"url": {
 							"raw": "http://localhost:9933/?",
@@ -162,7 +162,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"community_get_contacts\",\n    \"params\": {\n        \"prefix\": \"Al\",\n        \"community_id\": null\n    }\n}"
+							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"community_getContacts\",\n    \"params\": {\n        \"prefix\": \"Al\",\n        \"community_id\": null\n    }\n}"
 						},
 						"url": {
 							"raw": "http://localhost:9933/?",
@@ -197,7 +197,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"community_get_leader_board\",\n    \"params\": {}\n}"
+							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"community_getLeaderBoard\",\n    \"params\": {}\n}"
 						},
 						"url": {
 							"raw": "http://localhost:9933/?",
@@ -269,7 +269,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"get_tx_with_events\",\n    \"params\": {\n        \"block_number\": 1,\n        \"tx_index\": 1\n    }\n}",
+							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"get_txWithEvents\",\n    \"params\": {\n        \"block_number\": 1,\n        \"tx_index\": 1\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -335,7 +335,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"get_transaction_from_hashes\",\n    \"params\": {\n        \"tx_hashes\": [\n            \"0x33d191b41d83a930da61a0a8894e97caee2862ed25911e8fd41bc50e4602c53b\",\n            \"0x33d191b41d83a930da61a0a8894e97caee2862ed25911e8fd41bc50e4602c53b\"\n        ]\n    }\n}",
+							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"get_transactionFromHashes\",\n    \"params\": {\n        \"tx_hashes\": [\n            \"0x33d191b41d83a930da61a0a8894e97caee2862ed25911e8fd41bc50e4602c53b\",\n            \"0x33d191b41d83a930da61a0a8894e97caee2862ed25911e8fd41bc50e4602c53b\"\n        ]\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -439,7 +439,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"get_block_info\",\n    \"params\": {\n        \"block_height\": 5\n    }\n}",
+							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"get_blockInfo\",\n    \"params\": {\n        \"block_height\": 5\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -472,7 +472,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"get_blockchain_data\"\n}",
+							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"get_blockchainData\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -505,7 +505,78 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"get_genesis_data\"\n}",
+							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"get_genesisData\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:9933/",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9933",
+							"path": [
+								""
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Verifier",
+			"item": [
+				{
+					"name": "Verify",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"verifier_verify\",\n    \"params\": {\n        \"account_id\": \"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY\",\n        \"username\": \"Alice\",\n        \"phone_number\": \"+Alice\",\n        \"bypass_token\": \"dummy\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:9933/",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "9933",
+							"path": [
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Insert key",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"author_insertKey\",\n    \"params\": {\n        \"key_type\": \"Veri\",\n        \"suri\": \"//Alice\",\n        \"public\": \"30783547727776614546357A58623236467A397263517044575335374374455248704E6568584350634E6F48474B75745159\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -562,39 +633,6 @@
 			"response": []
 		},
 		{
-			"name": "Verify",
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"verify\",\n    \"params\": {\n        \"account_id\": \"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY\",\n        \"username\": \"Alice\",\n        \"phone_number\": \"+Alice\"\n    }\n}",
-					"options": {
-						"raw": {
-							"language": "json"
-						}
-					}
-				},
-				"url": {
-					"raw": "http://localhost:9933/",
-					"protocol": "http",
-					"host": [
-						"localhost"
-					],
-					"port": "9933",
-					"path": [
-						""
-					]
-				}
-			},
-			"response": []
-		},
-		{
 			"name": "Get blockchain events",
 			"request": {
 				"method": "POST",
@@ -606,7 +644,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"get_blockchain_events\",\n    \"params\": {\n        \"from_block_height\": 0, \n        \"to_block_height\": 2\n    }\n}",
+					"raw": "{\n    \"id\": 1,\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"get_blockchainEvents\",\n    \"params\": {\n        \"from_block_height\": 0, \n        \"to_block_height\": 2\n    }\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/client/rpc-api/src/chain/mod.rs
+++ b/client/rpc-api/src/chain/mod.rs
@@ -8,11 +8,11 @@ use sp_runtime::traits::Block as BlockT;
 #[rpc(client, server)]
 pub trait BlocksProviderApi<Block: BlockT, AccountId> {
 	/// RPC method provides block information by block number
-	#[method(name = "chain_get_block_info", blocking)]
+	#[method(name = "chain_getBlockInfo", blocking)]
 	fn get_block_info(&self, block_height: u32) -> RpcResult<RpcBlock<AccountId, Block::Hash>>;
 
 	/// RPC method provides blocks information by the range of blocks number
-	#[method(name = "chain_get_blocks", blocking)]
+	#[method(name = "chain_getBlocks", blocking)]
 	fn get_blocks(
 		&self,
 		from_block_height: u32,
@@ -24,10 +24,10 @@ pub trait BlocksProviderApi<Block: BlockT, AccountId> {
 	}
 
 	/// RPC method provides information about current blockchain state
-	#[method(name = "chain_get_blockchain_data")]
+	#[method(name = "chain_getBlockchainData")]
 	fn get_blockchain_data(&self) -> RpcResult<BlockchainStats>;
 
 	/// RPC method provides information about blockchain genesis config
-	#[method(name = "chain_get_genesis_data")]
+	#[method(name = "chain_getGenesisData")] 
 	fn get_genesis_data(&self) -> RpcResult<GenesisData<AccountId>>;
 }

--- a/client/rpc-api/src/events/mod.rs
+++ b/client/rpc-api/src/events/mod.rs
@@ -7,7 +7,7 @@ use sp_runtime::traits::Block as BlockT;
 #[rpc(client, server)]
 pub trait EventsProviderApi<Block: BlockT, Event> {
 	/// RPC method provides events for specific blocks
-	#[method(name = "events_get_blockchain_events", blocking)]
+	#[method(name = "events_getBlockchainEvents", blocking)]
 	fn get_blockchain_events(
 		&self,
 		from_block_height: u32,

--- a/client/rpc-api/src/identity/mod.rs
+++ b/client/rpc-api/src/identity/mod.rs
@@ -33,7 +33,7 @@ pub trait IdentityApi<BlockHash, AccountId, NameLimit: Get<u32>, PhoneNumberLimi
 
 	/// RPC method provides list of community members with information
 	/// about each member account
-	#[method(name = "community_get_all_users")]
+	#[method(name = "community_getAllUsers")]
 	fn get_all_users(
 		&self,
 		community_id: CommunityId,
@@ -42,7 +42,7 @@ pub trait IdentityApi<BlockHash, AccountId, NameLimit: Get<u32>, PhoneNumberLimi
 
 	/// RPC method provides list of users who's name starts with `prefix`
 	/// also can be filtered by `community_id`, `None` mean no filtering
-	#[method(name = "community_get_contacts")]
+	#[method(name = "community_getContacts")]
 	fn get_contacts(
 		&self,
 		prefix: BoundedString<NameLimit>,
@@ -51,6 +51,6 @@ pub trait IdentityApi<BlockHash, AccountId, NameLimit: Get<u32>, PhoneNumberLimi
 	) -> RpcResult<Vec<Contact<AccountId>>>;
 
 	/// RPC method provides info about karma rewards period leaderboard
-	#[method(name = "community_get_leader_board")]
+	#[method(name = "community_getLeaderBoard")]
 	fn get_leader_board(&self) -> RpcResult<Vec<LeaderboardEntry<AccountId>>>;
 }

--- a/client/rpc-api/src/transactions/mod.rs
+++ b/client/rpc-api/src/transactions/mod.rs
@@ -11,7 +11,7 @@ use sp_runtime::traits::{Block as BlockT, NumberFor};
 #[rpc(client, server)]
 pub trait TransactionsIndexerApi<Block: BlockT, AccountId, Signature, Event> {
 	/// RPC method provides transaction details by block number and transaction index
-	#[method(name = "transactions_get_tx", blocking)]
+	#[method(name = "transactions_getTx", blocking)]
 	fn get_tx(
 		&self,
 		block_number: NumberFor<Block>,
@@ -20,7 +20,7 @@ pub trait TransactionsIndexerApi<Block: BlockT, AccountId, Signature, Event> {
 
 	/// RPC method provides transaction details and transaction events by block number and
 	/// transaction index
-	#[method(name = "transactions_get_tx_with_events", blocking)]
+	#[method(name = "transactions_getTxWithEvents", blocking)]
 	fn get_tx_with_events(
 		&self,
 		block_number: NumberFor<Block>,
@@ -28,14 +28,14 @@ pub trait TransactionsIndexerApi<Block: BlockT, AccountId, Signature, Event> {
 	) -> RpcResult<(SignedTransactionWithStatus<AccountId, Signature>, Vec<Event>)>;
 
 	/// RPC method provides transaction details by transaction hash
-	#[method(name = "transactions_get_transaction", blocking)]
+	#[method(name = "transactions_getTransaction", blocking)]
 	fn get_transaction(
 		&self,
 		tx_hash: Block::Hash,
 	) -> RpcResult<GetTransactionResponse<AccountId, Signature, Event>>;
 
 	/// RPC method provides transactions details by transactions hashes
-	#[method(name = "transactions_get_transaction_from_hashes", blocking)]
+	#[method(name = "transactions_getTransactionFromHashes", blocking)]
 	fn get_transactions_from_hashes(
 		&self,
 		tx_hashes: Vec<Block::Hash>,
@@ -57,7 +57,7 @@ pub trait TransactionsIndexerApi<Block: BlockT, AccountId, Signature, Event> {
 	}
 
 	/// RPC method provides transactions, that belong to specific account
-	#[method(name = "transactions_get_transactions", blocking)]
+	#[method(name = "transactions_getTransactions", blocking)]
 	fn get_transactions(
 		&self,
 		account_id: AccountId,


### PR DESCRIPTION
It is more convenient for Substrate to name RPC method in camelCase so that `{module}_{methodName}`.