### PR TITLE
Integrate metadata into API

### DIFF
--- a/primitives/rpc/src/identity.rs
+++ b/primitives/rpc/src/identity.rs
@@ -36,6 +36,7 @@ pub struct UserInfo<AccountId> {
 	// pre_keys
 	pub karma_score: u32,
 	pub community_membership: Vec<CommunityMembership>,
+	pub metadata: Option<Vec<u8>>,
 }
 
 #[derive(Encode, Decode, TypeInfo)]
@@ -46,4 +47,5 @@ pub struct Contact<AccountId> {
 	pub phone_number_hash: PhoneNumberHash,
 	pub community_membership: Vec<CommunityMembership>,
 	pub trait_scores: Vec<TraitScore>,
+	pub metadata: Option<Vec<u8>>,
 }

--- a/runtime/src/api.rs
+++ b/runtime/src/api.rs
@@ -433,8 +433,8 @@ impl_runtime_apis! {
 						community_id, karma_score, is_admin
 					})
 					.collect::<Vec<_>>();
-
 				let karma_score = trait_scores.iter().map(|score| score.karma_score).sum::<u32>() + community_membership.len() as u32;
+				let metadata = Identity::metadata(&identity_info.account_id).map(Into::into);
 
 				UserInfo {
 					account_id: identity_info.account_id,
@@ -445,6 +445,7 @@ impl_runtime_apis! {
 					trait_scores,
 					karma_score,
 					community_membership,
+					metadata: metadata,
 				}
 			})
 		}
@@ -498,6 +499,7 @@ impl_runtime_apis! {
 							community_id, karma_score, is_admin
 						})
 						.collect();
+					let metadata = Identity::metadata(&account_id).map(Into::into);
 
 					Contact {
 						user_name: identity_store.username.try_into().unwrap_or_default(),
@@ -505,6 +507,7 @@ impl_runtime_apis! {
 						phone_number_hash: identity_store.phone_number_hash,
 						community_membership,
 						trait_scores,
+						metadata: metadata,
 					}
 				})
 				.collect()


### PR DESCRIPTION
Added metadata to `UserInfo` type and `Contact` type. So next API calls provide metadata:

- getLeaderboard()
- getCommunityMembers()
- getUserInfoByXXX()
- getContacts()