### PR TITLE
Fast runtime

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -103,6 +103,6 @@ runtime-benchmarks = ["karmachain-node-runtime/runtime-benchmarks", "frame-bench
 # Enable features that allow the runtime to be tried and debugged. Name might be subject to change
 # in the near future.
 try-runtime = ["karmachain-node-runtime/try-runtime", "try-runtime-cli/try-runtime"]
-dev = [
-	"karmachain-node-runtime/dev",
+fast-runtime  = [
+	"karmachain-node-runtime/fast-runtime",
 ]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -164,4 +164,4 @@ try-runtime = [
 	"pallet-babe/try-runtime",
 	"pallet-bags-list/try-runtime",
 ]
-dev = []
+fast-runtime = []

--- a/runtime/src/consts.rs
+++ b/runtime/src/consts.rs
@@ -11,10 +11,7 @@ pub const MILLISECS_PER_BLOCK: u64 = 12_000;
 // NOTE: Currently it is not possible to change the slot duration after the chain has started.
 //       Attempting to do so will brick block production.
 pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
-#[cfg(not(feature = "dev"))]
-pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = HOURS;
-#[cfg(feature = "dev")]
-pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = MINUTES;
+pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = prod_or_fast!(HOURS, MINUTES);
 pub const ERA_DURATION_IN_EPOCH: u32 = 6;
 
 // Time is measured by number of blocks.

--- a/runtime/src/consts.rs
+++ b/runtime/src/consts.rs
@@ -12,7 +12,7 @@ pub const MILLISECS_PER_BLOCK: u64 = 12_000;
 //       Attempting to do so will brick block production.
 pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK;
 pub const EPOCH_DURATION_IN_SLOTS: BlockNumber = prod_or_fast!(HOURS, MINUTES);
-pub const ERA_DURATION_IN_EPOCH: u32 = 6;
+pub const ERA_DURATION_IN_EPOCH: u32 = prod_or_fast!(6, 2);
 
 // Time is measured by number of blocks.
 pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);

--- a/runtime/src/pallets/election_provider_multi_phase.rs
+++ b/runtime/src/pallets/election_provider_multi_phase.rs
@@ -12,8 +12,14 @@ generate_solution_type!(
 
 parameter_types! {
 	// phase durations. 1/4 of the last session for each
-	pub SignedPhase: u32 = EPOCH_DURATION_IN_SLOTS / 4;
-	pub UnsignedPhase: u32 = EPOCH_DURATION_IN_SLOTS / 4;
+	pub SignedPhase: u32 = prod_or_fast!(
+		EPOCH_DURATION_IN_SLOTS / 4,
+		EPOCH_DURATION_IN_SLOTS
+	);
+	pub UnsignedPhase: u32 = prod_or_fast!(
+		EPOCH_DURATION_IN_SLOTS / 4,
+		EPOCH_DURATION_IN_SLOTS
+	);
 
 	// signed config
 	pub const SignedMaxSubmissions: u32 = 16;

--- a/runtime/src/pallets/staking.rs
+++ b/runtime/src/pallets/staking.rs
@@ -2,8 +2,8 @@ use crate::*;
 
 parameter_types! {
 	pub const SessionsPerEra: SessionIndex = ERA_DURATION_IN_EPOCH;
-	pub const BondingDuration: sp_staking::EraIndex = 28;
-	pub const SlashDeferDuration: sp_staking::EraIndex = 27;
+	pub const BondingDuration: sp_staking::EraIndex = 1;
+	pub const SlashDeferDuration: sp_staking::EraIndex = 0;
 	pub const MaxNominatorRewardedPerValidator: u32 = 512;
 	pub const OffendingValidatorsThreshold: Perbill = Perbill::from_percent(17);
 	pub const MaxNominations: u32 = <NposCompactSolution16 as frame_election_provider_support::NposSolution>::LIMIT as u32;

--- a/runtime/src/utils.rs
+++ b/runtime/src/utils.rs
@@ -89,3 +89,33 @@ impl sp_runtime::traits::Convert<sp_core::U256, Balance> for U256ToBalance {
 		n.try_into().defensive_unwrap_or(Balance::MAX)
 	}
 }
+
+/// Macro to set a value (e.g. when using the `parameter_types` macro) to either a production value
+/// or to an environment variable or testing value (in case the `fast-runtime` feature is selected).
+/// Note that the environment variable is evaluated _at compile time_.
+///
+/// Usage:
+/// ```Rust
+/// parameter_types! {
+/// 	// Note that the env variable version parameter cannot be const.
+/// 	pub LaunchPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1, "KSM_LAUNCH_PERIOD");
+/// 	pub const VotingPeriod: BlockNumber = prod_or_fast!(7 * DAYS, 1 * MINUTES);
+/// }
+/// ```
+#[macro_export]
+macro_rules! prod_or_fast {
+	($prod:expr, $test:expr) => {
+		if cfg!(feature = "fast-runtime") {
+			$test
+		} else {
+			$prod
+		}
+	};
+	($prod:expr, $test:expr, $env:expr) => {
+		if cfg!(feature = "fast-runtime") {
+			core::option_env!($env).map(|s| s.parse().ok()).flatten().unwrap_or($test)
+		} else {
+			$prod
+		}
+	};
+}

--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -4,10 +4,10 @@ set -e
 
 echo "Starting dev net"
 
-cargo build --release --features dev
+cargo build --release --features fast-runtime 
 
 run_node() {
-    cargo run --release --features dev -- --dev \
+    cargo run --release --features fast-runtime  -- --dev \
         --verifier \
         --bypass-token="dummy" \
         --auth-dst="https://localhost:8080" \


### PR DESCRIPTION
Rename `dev` feature into `fast-runtime`, it is more convenient name for substrate based chain. Also add `prod_or_fast` macro for code cleanest.
Fix election failure for `fast-runtime`